### PR TITLE
Remove errant vertexes on airplane path

### DIFF
--- a/suru-icons/status/scalable/airplane-mode-disabled.svg
+++ b/suru-icons/status/scalable/airplane-mode-disabled.svg
@@ -1,177 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="96"
-   height="96"
-   id="svg4874"
-   version="1.1"
-   inkscape:version="0.91+devel r"
-   viewBox="0 0 96 96.000001"
-   sodipodi:docname="airplane-mode-disabled.svg">
-  <defs
-     id="defs4876" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.5967996"
-     inkscape:cx="-96.530268"
-     inkscape:cy="33.293453"
-     inkscape:document-units="px"
-     inkscape:current-layer="g4780"
-     showgrid="true"
-     showborder="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-paths="true"
-     inkscape:bbox-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:snap-bbox-midpoints="true"
-     inkscape:object-paths="true"
-     inkscape:snap-intersection-paths="true"
-     inkscape:object-nodes="true"
-     inkscape:snap-smooth-nodes="true"
-     inkscape:snap-midpoints="true"
-     inkscape:snap-object-midpoints="true"
-     inkscape:snap-center="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid5451"
-       empspacing="8" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="8,-8.0000001"
-       id="guide4063"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="4,-8.0000001"
-       id="guide4065"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-8,88.000001"
-       id="guide4067"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-8,92.000001"
-       id="guide4069"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="104,4"
-       id="guide4071"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-5,8.0000001"
-       id="guide4073"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="92,-8.0000001"
-       id="guide4075"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="88,-8.0000001"
-       id="guide4077"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-8,84.000001"
-       id="guide4074"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="12,-8.0000001"
-       id="guide4076"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-5,12"
-       id="guide4078"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="84,-9.0000001"
-       id="guide4080"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="48,-8.0000001"
-       orientation="1,0"
-       id="guide4170"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="-8,48"
-       orientation="0,1"
-       id="guide4172"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata4879">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(67.857146,-78.50504)">
-    <g
-       transform="matrix(0,-1,-1,0,373.50506,516.50504)"
-       id="g4845"
-       style="display:inline">
-      <g
-         inkscape:export-ydpi="90"
-         inkscape:export-xdpi="90"
-         inkscape:export-filename="next01.png"
-         transform="matrix(-0.9996045,0,0,1,575.94296,-611.00001)"
-         id="g4778"
-         inkscape:label="Layer 1">
-        <g
-           transform="matrix(-1,0,0,1,575.99999,611)"
-           id="g4780"
-           style="display:inline">
-          <rect
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
-             id="rect4782"
-             width="96.037987"
-             height="96"
-             x="-438.00244"
-             y="345.36221"
-             transform="scale(-1,1)" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate;opacity:0.5"
-             d="M 86.708984 8 C 84.961824 8.7489437 83.050894 9.6432276 80.933594 10.679688 C 78.864144 11.70877 76.773262 12.88083 74.695312 14.173828 L 74.671875 14.150391 L 74.587891 14.255859 L 58.753906 30.076172 L 10.884766 15.998047 L 8 18.882812 L 44.941406 43.935547 C 41.916044 47.071854 39.415776 49.845877 36.785156 52.904297 C 34.975593 55.013136 31.83218 59.042005 28.789062 63.021484 L 10.220703 58.640625 L 8.015625 60.845703 L 22.828125 70.923828 C 22.514513 71.345756 22.056389 71.954757 21.808594 72.291016 L 23.705078 74.216797 C 24.044362 73.96683 24.659183 73.502812 25.085938 73.185547 L 35.154297 87.984375 L 37.359375 85.779297 L 32.982422 67.226562 C 36.970535 64.175155 41.009402 61.023201 43.119141 59.212891 C 46.17708 56.583049 48.936269 54.08255 52.064453 51.058594 L 77.117188 87.998047 L 80 85.115234 L 65.925781 37.259766 L 81.765625 21.433594 L 81.847656 21.353516 L 81.824219 21.330078 C 83.120149 19.247512 84.297329 17.150062 85.318359 15.066406 C 86.366189 12.959 87.25128 11.037964 88 9.2910156 L 86.708984 8 z "
-             transform="matrix(0,-1,-1.0003957,0,438.00245,441.36222)"
-             id="path6255" />
-        </g>
-      </g>
+<svg id="svg4874" width="96" height="96" version="1.1" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata4879">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(67.857 -78.505)">
+  <g id="g4845" transform="matrix(0 -1 -1 0 373.51 516.51)">
+   <g id="g4778" transform="matrix(-.9996 0 0 1 575.94 -611)">
+    <g id="g4780" transform="matrix(-1 0 0 1 576 611)">
+     <rect id="rect4782" transform="scale(-1,1)" x="-438" y="345.36" width="96.038" height="96" color="#000000" fill="none"/>
+     <path id="path6255" transform="matrix(0 -1 -1.0004 0 438 441.36)" d="m86.709 8c-1.7472 0.74894-3.6581 1.6432-5.7754 2.6797-2.2844 1.1715-4.5263 2.4322-6.3457 3.5762l-15.834 15.82-47.869-14.078-2.8848 2.8848 36.941 25.053c-3.0254 3.1363-5.5256 5.9103-8.1562 8.9688-1.8096 2.1088-4.953 6.1377-7.9961 10.117l-18.568-4.3809-2.2051 2.2051 14.812 10.078c-0.31361 0.42193-0.77174 1.0309-1.0195 1.3672l1.8965 1.9258c0.33928-0.24997 0.9541-0.71398 1.3809-1.0312l10.068 14.799 2.2051-2.2051-4.377-18.553c3.9881-3.0514 8.027-6.2034 10.137-8.0137 3.0579-2.6298 5.8171-5.1303 8.9453-8.1543l25.053 36.939 2.8828-2.8828-14.074-47.855 15.84-15.826c1.2691-2.0885 2.5981-4.4298 3.5527-6.3672 1.0478-2.1074 1.9329-4.0284 2.6816-5.7754z" color="#000000" fill="#808080" opacity=".5"/>
     </g>
+   </g>
   </g>
+ </g>
 </svg>

--- a/suru-icons/status/scalable/airplane-mode.svg
+++ b/suru-icons/status/scalable/airplane-mode.svg
@@ -1,175 +1,25 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="96"
-   height="96"
-   id="svg4874"
-   version="1.1"
-   inkscape:version="0.91+devel r"
-   viewBox="0 0 96 96.000001"
-   sodipodi:docname="airplane-mode.svg">
-  <defs
-     id="defs4876" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.5967996"
-     inkscape:cx="24.688607"
-     inkscape:cy="35.100615"
-     inkscape:document-units="px"
-     inkscape:current-layer="g4780"
-     showgrid="true"
-     showborder="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-paths="true"
-     inkscape:bbox-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:snap-bbox-midpoints="true"
-     inkscape:object-paths="true"
-     inkscape:snap-intersection-paths="true"
-     inkscape:object-nodes="true"
-     inkscape:snap-smooth-nodes="true"
-     inkscape:snap-midpoints="true"
-     inkscape:snap-object-midpoints="true"
-     inkscape:snap-center="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid5451"
-       empspacing="8" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="8,-8.0000001"
-       id="guide4063" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="4,-8.0000001"
-       id="guide4065" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-8,88.000001"
-       id="guide4067" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-8,92.000001"
-       id="guide4069" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="104,4"
-       id="guide4071" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-5,8.0000001"
-       id="guide4073" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="92,-8.0000001"
-       id="guide4075" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="88,-8.0000001"
-       id="guide4077" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-8,84.000001"
-       id="guide4074" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="12,-8.0000001"
-       id="guide4076" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="-5,12"
-       id="guide4078" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="84,-9.0000001"
-       id="guide4080" />
-    <sodipodi:guide
-       position="48,-8.0000001"
-       orientation="1,0"
-       id="guide4170" />
-    <sodipodi:guide
-       position="-8,48"
-       orientation="0,1"
-       id="guide4172" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata4879">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(67.857146,-78.50504)">
-    <g
-       transform="matrix(0,-1,-1,0,373.50506,516.50504)"
-       id="g4845"
-       style="display:inline">
-      <g
-         inkscape:export-ydpi="90"
-         inkscape:export-xdpi="90"
-         inkscape:export-filename="next01.png"
-         transform="matrix(-0.9996045,0,0,1,575.94296,-611.00001)"
-         id="g4778"
-         inkscape:label="Layer 1">
-        <g
-           transform="matrix(-1,0,0,1,575.99999,611)"
-           id="g4780"
-           style="display:inline">
-          <rect
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
-             id="rect4782"
-             width="96.037987"
-             height="96"
-             x="-438.00244"
-             y="345.36221"
-             transform="scale(-1,1)" />
-          <path
-             sodipodi:nodetypes="cccccccc"
-             inkscape:connector-curvature="0"
-             id="path6255"
-             d="m 349.98354,406.20839 16.15668,10.98737 10.99179,16.15026 2.20603,-2.20527 -4.5939,-19.45812 -3.08849,-3.08737 -19.46597,-4.59212 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.00118685;marker:none;enable-background:accumulate" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.00118732;marker:none;enable-background:accumulate"
-             d="m 421.99809,430.47684 -2.88653,2.88539 -27.94135,-41.18635 -41.20061,-27.93029 2.8845,-2.88336 48.57844,14.28189 6.27802,6.27553 14.28753,48.55719 z"
-             id="path6259"
-             inkscape:connector-curvature="0" />
-          <path
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00019777"
-             d="m 429.99927,354.65255 -1.29079,-1.29016 c -1.74764,0.74872 -3.67104,1.63285 -5.77928,2.68068 -2.08448,1.02103 -4.18252,2.19951 -6.26591,3.49544 l -0.0231,-0.0235 -0.0805,0.0813 -26.31731,26.33051 c -4.65005,4.64818 -7.94329,8.20985 -11.47547,12.31539 -3.47653,4.04995 -11.9604,15.27656 -15.00993,19.41411 l 1.92547,1.89827 c 4.13902,-3.04891 15.34321,-11.50178 19.39475,-14.97697 4.10686,-3.53101 7.6955,-6.82454 12.34554,-11.47275 l 26.31745,-26.3305 0.10669,-0.0833 -0.0232,-0.0235 c 1.29351,-2.07795 2.46547,-4.16872 3.49496,-6.23817 1.03687,-2.1173 1.93131,-4.02972 2.68055,-5.77688 z"
-             id="path6261"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccccccccccccccc" />
-        </g>
-      </g>
+<svg id="svg4874" width="96" height="96" version="1.1" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata4879">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" transform="translate(67.857 -78.505)">
+  <g id="g4845" transform="matrix(0 -1 -1 0 373.51 516.51)">
+   <g id="g4778" transform="matrix(-.9996 0 0 1 575.94 -611)">
+    <g id="g4780" transform="matrix(-1 0 0 1 576 611)">
+     <rect id="rect4782" transform="scale(-1,1)" x="-438" y="345.36" width="96.038" height="96" color="#000000" fill="none"/>
+     <path id="path6255" d="m349.98 406.21 16.157 10.987 10.992 16.15 2.206-2.2053-4.5939-19.458-3.0885-3.0874-19.466-4.5921z" color="#000000" fill="#808080"/>
+     <path id="path6259" d="m422 430.48-2.8865 2.8854-27.941-41.186-41.201-27.93 2.8845-2.8834 48.578 14.282 6.278 6.2755 14.288 48.557z" color="#000000" fill="#808080"/>
+     <path id="path6261" d="m430 354.65-1.2908-1.2902c-1.7476 0.74872-3.671 1.6328-5.7793 2.6807-2.2831 1.1647-4.5378 2.4249-6.3695 3.5532l-26.317 26.331c-4.65 4.6482-7.9433 8.2098-11.475 12.315-3.4765 4.05-11.96 15.277-15.01 19.414l1.9255 1.8983c4.139-3.0489 15.343-11.502 19.395-14.977 4.1069-3.531 7.6955-6.8245 12.346-11.473 8.7242-8.8806 17.734-17.521 26.401-26.437 1.2935-2.078 2.4655-4.1687 3.495-6.2382 1.0369-2.1173 1.9313-4.0297 2.6806-5.7769z" fill="#808080"/>
     </g>
+   </g>
   </g>
+ </g>
 </svg>


### PR DESCRIPTION
This is a small change by @mbblp which removes a couple of vertexes from the airplane mode icon. These made it a bit strange to use in Inkscape. There is no visible change at most used sizes, it's only visible when it's blown up very large.

Additionally I ran the SVGs through `scour`. It appears it is easier to open and edit them after this, rather than keeping all the metadata from Inkscape.